### PR TITLE
fix: Router basename trailing-slash and palette semicolons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ A repository ruleset ("Branch Protection Best Practices") is active and applies 
 - Committed pre-existing `.editorconfig` that was untracked
 - `colours` is now fully aligned with the cross-repo standard stack
 
-### Completed (2026-05-07) — PR #66 (open, pending merge)
+### Completed (2026-05-07) — PR #66
 
 - Added Prettier (`prettier@3`, `eslint-config-prettier`) with default settings
 - Added `.prettierrc` (`{}`), `.prettierignore` (dist/netlify/coverage/.yarn/lock files)
@@ -98,13 +98,15 @@ A repository ruleset ("Branch Protection Best Practices") is active and applies 
 - Added `yarn format:check` to `.github/workflows/test.yml` CI
 - Applied initial format pass across all source files (whitespace/quote/semicolon only — no logic changes)
 - Fixed README CSS code block that Prettier mangled: added `<!-- prettier-ignore -->` and restored each custom property to its own line with trailing semicolons
-- Added TODO in `index.html` for Router basename trailing-slash redirect
-- Added TODO in `PaletteGenerator.tsx` for appending trailing semicolons to custom property output
+
+### Completed (2026-05-07) — PR #67 (open, pending merge)
+
+- Added Router basename trailing-slash redirect script in `index.html` using `%BASE_URL%` (Vite template variable); preserves query string and hash on redirect; no-op for Netlify build
+- Appended trailing semicolon to each CSS custom property line in Palette Generator output; tightened copy-block test assertions to verify format
 
 ### Outstanding / next (this repo)
 
-- **Router trailing-slash fix** — `<BrowserRouter basename="/colours/">` emits a warning when the URL is `/colours` (no trailing slash). Add a `<script>` in `index.html` `<head>` that redirects bare basename to basename + `/` before React hydrates. See TODO comment in `index.html`.
-- **Palette custom property semicolons** — each `--name-N: #hex` line should end with `;`. Update the map in `PaletteGenerator.tsx`, the README example, and the test assertions. See TODO comment in the file.
+- No known outstanding work for `colours` specifically
 
 ### Outstanding / next (cross-repo — other repos)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,12 +48,13 @@ src/
 - **CSS**: CSS Modules (`.module.scss`) for component styles; `camelCase` locals convention (set in `vite.config.ts`). Global styles in `src/styles/global.scss`.
 - **Testing**: Vitest + React Testing Library, `happy-dom` environment. Tests live alongside source files. Run all tests with `yarn test --run`. Do not mock internal utilities — test against real implementations.
 - **TypeScript**: strict mode with `noUnusedLocals` and `noUnusedParameters` — the build will fail if unused symbols are introduced.
-- **Linting**: ESLint v9 flat config (`eslint.config.js`) with `typescript-eslint` and `eslint-plugin-react-hooks`.
+- **Linting**: ESLint v9 flat config (`eslint.config.js`) with `typescript-eslint`, `eslint-plugin-react-hooks`, and `eslint-config-prettier` (last in chain, disables rules that conflict with Prettier).
+- **Formatting**: Prettier with default settings (`.prettierrc` is `{}`). Run `yarn format` to write, `yarn format:check` to verify. The pre-commit hook runs `prettier --check` before lint/type-check/tests. CI also runs `yarn format:check`.
 - **Commit messages**: enforced by the `commit-msg` hook. Format: `type(optional-scope): description`. Valid types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `style`, `perf`, `build`, `ci`, `revert`.
 
 ## CI
 
-A GitHub Actions workflow (`.github/workflows/test.yml`) runs `yarn test --run` on every push to `main` and on every pull request. The pre-commit hook runs lint + type-check + tests locally before each commit, so CI failures on a PR should be rare.
+A GitHub Actions workflow (`.github/workflows/test.yml`) runs `yarn format:check` and `yarn test --run` on every push to `main` and on every pull request. The pre-commit hook runs prettier check + lint + type-check + tests locally before each commit, so CI failures on a PR should be rare.
 
 ## Repository protection
 
@@ -87,9 +88,23 @@ A repository ruleset ("Branch Protection Best Practices") is active and applies 
 - Committed pre-existing `.editorconfig` that was untracked
 - `colours` is now fully aligned with the cross-repo standard stack
 
+### Completed (2026-05-07) — PR #66 (open, pending merge)
+
+- Added Prettier (`prettier@3`, `eslint-config-prettier`) with default settings
+- Added `.prettierrc` (`{}`), `.prettierignore` (dist/netlify/coverage/.yarn/lock files)
+- Extended `eslint.config.js` with `prettierConfig` as final entry
+- Added `format` / `format:check` scripts to `package.json`
+- Added `yarn prettier --check .` as first step of `.husky/pre-commit`
+- Added `yarn format:check` to `.github/workflows/test.yml` CI
+- Applied initial format pass across all source files (whitespace/quote/semicolon only — no logic changes)
+- Fixed README CSS code block that Prettier mangled: added `<!-- prettier-ignore -->` and restored each custom property to its own line with trailing semicolons
+- Added TODO in `index.html` for Router basename trailing-slash redirect
+- Added TODO in `PaletteGenerator.tsx` for appending trailing semicolons to custom property output
+
 ### Outstanding / next (this repo)
 
-- No known outstanding work for `colours` specifically
+- **Router trailing-slash fix** — `<BrowserRouter basename="/colours/">` emits a warning when the URL is `/colours` (no trailing slash). Add a `<script>` in `index.html` `<head>` that redirects bare basename to basename + `/` before React hydrates. See TODO comment in `index.html`.
+- **Palette custom property semicolons** — each `--name-N: #hex` line should end with `;`. Update the map in `PaletteGenerator.tsx`, the README example, and the test assertions. See TODO comment in the file.
 
 ### Outstanding / next (cross-repo — other repos)
 

--- a/index.html
+++ b/index.html
@@ -5,12 +5,14 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Colours + Contrast</title>
-    <!-- TODO: add a <script> that appends a trailing slash to location.pathname
-         when it equals the bare basename ("/colours") so that BrowserRouter
-         does not emit the "Router basename is not able to match the URL"
-         warning. Pattern used in other projects: if (!location.pathname.endsWith('/'))
-         location.replace(location.pathname + '/') — place before the module
-         script so the redirect happens before React hydrates. -->
+    <script>
+      // Redirect /colours → /colours/ so BrowserRouter basename matching works.
+      // %BASE_URL% is replaced by Vite at build time (e.g. "/colours/" for
+      // the GitHub Pages build, "/" for Netlify). Has no effect when base is "/".
+      if (location.pathname === "%BASE_URL%".replace(/\/$/, "")) {
+        location.replace("%BASE_URL%");
+      }
+    </script>
     <meta
       name="keywords"
       content="Craig McNaughton, software developer, software development, colour, color, contrast, opacity"

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       // %BASE_URL% is replaced by Vite at build time (e.g. "/colours/" for
       // the GitHub Pages build, "/" for Netlify). Has no effect when base is "/".
       if (location.pathname === "%BASE_URL%".replace(/\/$/, "")) {
-        location.replace("%BASE_URL%");
+        location.replace("%BASE_URL%" + location.search + location.hash);
       }
     </script>
     <meta

--- a/src/pages/PaletteGenerator/PaletteGenerator.test.tsx
+++ b/src/pages/PaletteGenerator/PaletteGenerator.test.tsx
@@ -19,7 +19,7 @@ vi.mock("../../hooks/useClipboard");
 // Hex values live inside a <div> interleaved with <br> nodes (rgb, hsl, hex),
 // so getByText(hexStr) won't find them. Instead we inspect the <pre> element,
 // which renders each CSS variable as its own <span> text, e.g.:
-//   --grey-500: #808080
+//   --grey-500: #808080;
 
 beforeEach(() => {
   vi.mocked(useClipboard).mockReturnValue({
@@ -354,9 +354,10 @@ describe("copy interactions", () => {
     ];
     // variablesText = variables.join('\n') → 12 lines joined by newline
     expect(text.split("\n")).toHaveLength(12);
-    expect(text).toMatch(/--gr[ae]y-0: #ffffff/);
-    expect(text).toMatch(/--gr[ae]y-500: #808080/);
+    expect(text).toMatch(/--gr[ae]y-0: #ffffff;/);
+    expect(text).toMatch(/--gr[ae]y-500: #808080;/);
     expect(text).not.toMatch(/\n$/); // joined, not terminated
+    expect(text).not.toMatch(/;;/); // exactly one semicolon per line
   });
 
   it("the copied variable block uses the typed Name when set", async () => {

--- a/src/pages/PaletteGenerator/PaletteGenerator.tsx
+++ b/src/pages/PaletteGenerator/PaletteGenerator.tsx
@@ -47,14 +47,9 @@ export const PaletteGenerator = () => {
     name || (base.inputValue ? nearestNamedColor(base.color.rgb) : "grey"),
   );
 
-  // TODO: append a trailing semicolon to each custom property value so the
-  // output is valid CSS and matches the README example, e.g.
-  // `--brand-500: #003cfa;` instead of `--brand-500: #003cfa`.
-  // Update the README code block and the variablesText snapshot / assertions
-  // in PaletteGenerator.test.tsx at the same time.
   const variables = palette.map((rgb, index) => {
     const i = index === 0 ? 0 : index === 1 ? 50 : (index - 1) * 100;
-    return `--${colorName}-${i}: ${rgb2Hex(rgb, true)}`;
+    return `--${colorName}-${i}: ${rgb2Hex(rgb, true)};`;
   });
   const variablesText = variables.join("\n");
 


### PR DESCRIPTION
## What

Two small fixes carried over as TODOs from PR #66.

**Router basename trailing-slash redirect**
Adds a compact inline script to `index.html` that redirects the bare basename URL (`/colours`) to its trailing-slash form (`/colours/`) before React hydrates. Without this, `BrowserRouter` emits a warning because its `basename` (set from `import.meta.env.BASE_URL`) requires a trailing slash but the incoming URL doesn't have one. Uses Vite's `%BASE_URL%` template variable so the redirect is a no-op for the Netlify build (base `"/"`).

**Palette CSS custom property semicolons**
Each line of the generated custom properties block now ends with `;`, making the output valid CSS that can be pasted directly into a `:root {}` rule. Updated the format comment and copy-block test assertions to document and verify the new format.

Also carries forward the CLAUDE.md checkpoint commit (`fb34de1`) that was orphaned when PR #66 was merged before it could be pushed.

## Test plan

- [ ] `yarn format:check` exits 0
- [ ] `yarn lint` exits 0
- [ ] `yarn test --run` — 378 tests pass
- [ ] `tsc -b` — no type errors
- [ ] Palette Generator: copied CSS block ends each line with `;`
- [ ] GitHub Pages build (`yarn build --base=/colours/`): navigating to `/colours` (no trailing slash) redirects to `/colours/`
- [ ] Netlify build (default base): no redirect fires at `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)